### PR TITLE
HOME-274 - When adding  agent error occurs

### DIFF
--- a/models/type1/type1.go
+++ b/models/type1/type1.go
@@ -40,7 +40,7 @@ type IType1 interface {
 
 // Type1 - hardware entity
 type Type1 struct {
-	agent.Agent
+	agent.Agent      `bson:",inline"`
 	tmpNotifyTime    time.Time
 	motionNotifyTime time.Time
 	gasNotifyTime    time.Time

--- a/processes/homebot/homebot.go
+++ b/processes/homebot/homebot.go
@@ -63,7 +63,7 @@ func persistDataFactory(
 	agentConfig agent.Config,
 ) func(agent.IAgent, map[string]interface{}) {
 	return func(ia agent.IAgent, data map[string]interface{}) {
-		a, ok := ia.(*agent.Agent)
+		a, ok := ia.(*type1.Type1)
 
 		if !ok {
 			utils.Log("assertion type error")
@@ -105,8 +105,7 @@ func (hb *HomeBot) runCommunicationLoop() {
 			t1, ok := it1.(*type1.Type1)
 
 			if !ok {
-				utils.Log("type assertion error")
-				return
+				continue
 			}
 
 			cnf, err := hb.persistence.FindOneAgentConfig(bson.M{


### PR DESCRIPTION
**Business justification:** https://trello.com/c/BTZQlZaI/274-home-274-when-adding-type1-agent-error-occurs

**Description:** Fix how type1 BSON is stored by using `bson:",inline"` to flatten storage of embedded struct. Afterwards type assertion should be adjusted when asserting state agents in agents controller.