### PR TITLE
HOME-280 - Don't allow to add agent duplicates

### DIFF
--- a/datasources/state/state.go
+++ b/datasources/state/state.go
@@ -95,6 +95,13 @@ func (s *State) SendAlert() bool {
 
 // AddAgent - adds agent to the memory state
 func (s *State) AddAgent(id string, name string, ip string, agentType string) {
+	_, err := s.AgentByID(id)
+
+	if err == nil {
+		utils.Log("not adding agent '" + id + "', agent already exists")
+		return
+	}
+
 	utils.Log("adding home agent '" + name + "' with URL '" + ip + "'")
 	rawType := strings.Split(agentType, "-")[0]
 

--- a/datasources/state/state_test.go
+++ b/datasources/state/state_test.go
@@ -18,6 +18,7 @@ func TestAgentByID(t *testing.T) {
 	p := mock.NewPersistanceMock(
 		"db-uri",
 		"smarthome",
+		false,
 	)
 
 	s := New(p, agents)
@@ -49,6 +50,7 @@ func TestRemoveAgent(t *testing.T) {
 	p := mock.NewPersistanceMock(
 		"db-uri",
 		"smarthome",
+		false,
 	)
 
 	s := New(p, agents)
@@ -71,6 +73,41 @@ func TestRemoveAgent(t *testing.T) {
 
 		if err.Error() != expectedResult.Error() {
 			t.Errorf("Wrong error returned")
+		}
+	})
+}
+
+func TestAddAgent(t *testing.T) {
+	agents := []agent.IAgent{}
+
+	p := mock.NewPersistanceMock(
+		"db-uri",
+		"smarthome",
+		true,
+	)
+
+	t.Run("Should add agent", func(t *testing.T) {
+		s := New(p, agents)
+		s.AddAgent("bedroom", "Bed room", "192.168.1.3", types.Type2)
+
+		if len(s.model.Agents) != 1 {
+			t.Errorf("Should have added one agent")
+		}
+
+		s.AddAgent("livingroom", "Living room", "192.168.1.2", types.Type1)
+
+		if len(s.model.Agents) != 2 {
+			t.Errorf("Should have added second agent")
+		}
+	})
+
+	t.Run("Should not add duplicated agents", func(t *testing.T) {
+		s := New(p, agents)
+		s.AddAgent("bedroom", "Bed room 1", "192.168.1.2", types.Type2)
+		s.AddAgent("bedroom", "Bed room 2", "192.168.1.3", types.Type2)
+
+		if len(s.model.Agents) != 1 {
+			t.Errorf("Should have added one agent")
 		}
 	})
 }

--- a/mock/persistence.go
+++ b/mock/persistence.go
@@ -12,13 +12,15 @@ import (
 type PersistanceMock struct {
 	session *mgo.Session
 	dbName  string
+	empty   bool
 }
 
 // NewPersistanceMock - creates new persistence mock
-func NewPersistanceMock(dbURI string, dbName string) *PersistanceMock {
+func NewPersistanceMock(dbURI string, dbName string, empty bool) *PersistanceMock {
 	return &PersistanceMock{
 		&mgo.Session{},
 		dbName,
+		empty,
 	}
 }
 
@@ -48,9 +50,13 @@ func (p *PersistanceMock) FindAllAgentConfigs(query interface{}) ([]agent.Config
 
 // FindOneState - find one state entry
 func (p *PersistanceMock) FindOneState(query interface{}) (state.State, error) {
-	agent1 := agent.New("livingroom", "Living room", "192.168.1.2", types.Type1)
-	agent2 := agent.New("bedroom", "Bed room", "192.168.1.3", types.Type2)
-	agents := []agent.IAgent{agent1, agent2}
+	agents := []agent.IAgent{}
+
+	if !p.empty {
+		agent1 := agent.New("livingroom", "Living room", "192.168.1.2", types.Type1)
+		agent2 := agent.New("bedroom", "Bed room", "192.168.1.3", types.Type2)
+		agents = append(agents, agent1, agent2)
+	}
 
 	s := state.State{
 		IsAlerts:  false,


### PR DESCRIPTION
**Business justification:** https://trello.com/c/ABJMp369/280-home-dont-allow-to-add-agent-duplicates

**Description:** When re-deploying shapi, it sniffs for existing agents, and it adds 'em. The issue arises then previously sniffed and persisted agents are concatenated with newly sniffed agents. It causes duplicates of the agents on every re-deploy. 

This PR makes sure that when using state function `AddAgent` it checks for dups first.