### PR TITLE
HOME-282 - Prevent making agent duplicates on bootstrap time

### DIFF
--- a/datasources/state/state.go
+++ b/datasources/state/state.go
@@ -95,6 +95,7 @@ func (s *State) SendAlert() bool {
 
 // AddAgent - adds agent to the memory state
 func (s *State) AddAgent(id string, name string, ip string, agentType string) {
+	s.load()
 	_, err := s.AgentByID(id)
 
 	if err == nil {


### PR DESCRIPTION
**Business justification:** https://trello.com/c/Z56t7IOZ/282-home-prevent-making-agent-duplicates-on-bootstrap-time

**Description:** When sniffing agents on bootstrap time, state isn't loaded, it should be loaded first to see whether added agent already exist.
