### PR TITLE
HOME-283 - Add versions to slack notifier

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", 'curl -X POST -H "Content-type: application/json" --data "{\"text\":\"sh-api deployed\"}" NOTIFIER_URL']
+                command: ["/bin/sh", "-c", 'curl -X POST -H "Content-type: application/json" --data "{\"text\":\"sh-api VERSION deployed\"}" NOTIFIER_URL']
         - image: mongo:latest
           imagePullPolicy: IfNotPresent
           name: sh-mongodb


### PR DESCRIPTION
**Business justification:** https://trello.com/c/m7jXYXxJ/283-home-283-add-versions-to-slack-notifier

**Description:** When Kubernetes starts pods developers should be notified, which version is deployed.