### PR TITLE
HOME-212 - Landing page API version

### DIFF
--- a/processes/webserver/controllers/api/front/all.go
+++ b/processes/webserver/controllers/api/front/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/coda-it/gowebserver/router"
 	"github.com/coda-it/gowebserver/session"
 	"github.com/coda-it/gowebserver/store"
+	"github.com/smart-evolution/shapi/utils"
 	"net/http"
 )
 
@@ -12,7 +13,9 @@ func (c *Controller) CtrFrontAll(w http.ResponseWriter, r *http.Request, opt rou
 	defer r.Body.Close()
 	c.CorsHeaders(w, r)
 
-	data := struct{}{}
+	data := map[string]string{
+		"version": utils.VERSION,
+	}
 	links := map[string]map[string]string{
 		"self": map[string]string{
 			"href": "/api/",


### PR DESCRIPTION
**Business justification:** https://trello.com/c/kQ09r3AQ/212-home-212-landing-page-api-version

**Description:** Introduce `version` to landing page to let users know which API version is currently on.